### PR TITLE
Add Custom `int.date` Textual Converters

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -341,10 +341,10 @@ func newSymbolTable() map[string]*Codec {
 			typeName:          &name{"int.date", nullNamespace},
 			schemaOriginal:    "int",
 			schemaCanonical:   "int",
-			nativeFromTextual: nativeFromDate(intNativeFromTextual),
+			nativeFromTextual: nativeFromTextualDate,
 			binaryFromNative:  dateFromNative(intBinaryFromNative),
 			nativeFromBinary:  nativeFromDate(intNativeFromBinary),
-			textualFromNative: dateFromNative(intTextualFromNative),
+			textualFromNative: textualFromNativeDate,
 		},
 		"com.salsify.salsify_uuid_binary": {
 			typeName:          &name{"salsify_uuid_binary", "com.salsify"},

--- a/logical_type.go
+++ b/logical_type.go
@@ -64,6 +64,38 @@ func dateFromNative(fn fromNativeFn) fromNativeFn {
 	}
 }
 
+func nativeFromTextualDate(buf []byte) (interface{}, []byte, error) {
+	native, _, err := stringNativeFromTextual(buf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stringNative, ok := native.(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("cannot decode textual date: expected string, received %T", native)
+	}
+
+	t, err := time.Parse(time.DateOnly, stringNative)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot decode textual date")
+	}
+
+	return t, buf, nil
+}
+
+func textualFromNativeDate(buf []byte, d interface{}) ([]byte, error) {
+	date, ok := d.(time.Time)
+
+	if !ok {
+		return nil, fmt.Errorf("cannot encode to textual date, expected time.Time, received %T", date)
+	}
+
+	buf = append(buf, '"')
+	buf = append(buf, date.Format(time.DateOnly)...)
+	buf = append(buf, '"')
+	return buf, nil
+}
+
 // ////////////////////////////////////////////////////////////////////////////////////////////
 // time-millis logical type - to/from time.Time, time.UTC location
 // ////////////////////////////////////////////////////////////////////////////////////////////

--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -15,12 +15,34 @@ import (
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
 	precision = "precision"
 	scale     = "scale"
 )
+
+func TestTextualFromNativeDate(t *testing.T) {
+	date := time.Date(2010, 11, 9, 0, 0, 0, 0, time.UTC)
+	buf := make([]byte, 0)
+
+	buf, err := textualFromNativeDate(buf, date)
+
+	assert.NoError(t, err)
+	assert.Equal(t, buf, []byte("\"2010-11-09\""))
+}
+
+func TestNativeFromTextualDate(t *testing.T) {
+	date := []byte("\"2010-11-09\"")
+	expected := time.Date(2010, 11, 9, 0, 0, 0, 0, time.UTC)
+
+	native, _, err := nativeFromTextualDate(date)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, native)
+}
 
 func TestSchemaLogicalType(t *testing.T) {
 	testSchemaValid(t, `{"type": "long", "logicalType": "timestamp-millis"}`)


### PR DESCRIPTION
We'd rather have the `int.date` type's textual output be a string-ified (`2024-09-26`) instead of an int representing days since epoch (`739520`). 

This PR overrides the current textual conversion methods for the `int.date` method.

This won't output an ISO6801 timestamp matching our current implementation, but the `time.DateOnly` format should play nicely.

prime @erikkessler1 