### PR TITLE
Handle Julian dates [PIMCORE-1899]

### DIFF
--- a/logical_type_test.go
+++ b/logical_type_test.go
@@ -34,6 +34,33 @@ func TestTextualFromNativeDate(t *testing.T) {
 	assert.Equal(t, buf, []byte("\"2010-11-09\""))
 }
 
+func TestTextualFromNativeDate_WithJulianDates(t *testing.T) {
+	cases := map[int]string{
+		-141426: "1582-10-16",
+		-141427: "1582-10-15",
+		-141428: "1582-10-04",
+		-141429: "1582-10-03",
+		-171596: "1500-02-29",
+		-171597: "1500-02-28",
+		-682944: "0100-03-02",
+		-682945: "0100-03-01",
+		-682946: "0100-02-29",
+		-718466: "0002-11-30",
+		-719530: "0000-01-01",
+	}
+
+	for caseDate, expected := range cases {
+		date := time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, caseDate).UTC()
+		buf := make([]byte, 0)
+
+		buf, err := textualFromNativeDate(buf, date)
+		assert.NoError(t, err)
+
+		expectedBuf := fmt.Sprintf("\"%s\"", expected)
+		assert.Equal(t, buf, []byte(expectedBuf))
+	}
+}
+
 func TestNativeFromTextualDate(t *testing.T) {
 	date := []byte("\"2010-11-09\"")
 	expected := time.Date(2010, 11, 9, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Problem

Dates from before 1582-10-15 don't get handled as we want. For example, `0002-11-30` will get converted to `0002-11-28`. 

This happens because Ruby, by default, will treat dates from before `1582-10-15` as Julian dates and after as Gregorian: https://github.com/ruby/date/blob/c2d9cc29280e0eabb0bc72175c80704f1737a9fb/doc/date/calendars.rdoc#L37

```ruby
Date.iso8601('1582-10-15').gregorian?
#=> true

Date.iso8601('1582-10-14').gregorian?
#=> invalid date (Date::Error)

Date.iso8601('1582-10-04').julian?
#=> true

Date.iso8601('0002-10-30').gregorian
#=> Mon, 28 Oct 0002
```

Go, on the other hand, always uses Gregorian. From the [`time` package](https://pkg.go.dev/time#Time.Equal):

> The calendrical calculations always assume a Gregorian calendar, with no leap seconds.

## Solution

I looked for libraries that could do this conversion for us, but I didn't find any that seemed to work for the date ranges we want to support. Those that I looked at included:

* [golang-module/carbon](https://github.com/golang-module/carbon): Pretty large dependency to add and didn't seem to work
* [soniakeys/meeus](https://github.com/soniakeys/meeus): Could get it to work, but no longer maintained and seemed like more of a personal side project

This pages lays out a easy-to-follow table for converting between Julian and Gregorian dates: https://en.wikipedia.org/wiki/Conversion_between_Julian_and_Gregorian_calendars and serves as the basis for this solution.

There are complicated-looking formulas with magic numbers and operations that could work, but I'd worry about fixing a bug or maintaining those magical formulas, so I opted for this more manual algorithm that I believe should be easier to reason about and maintain. Note, it doesn't support negative dates, but we don't have any uses of that.

prime: @marcoserrato 


[PIMCORE-1899]

[PIMCORE-1899]: https://salsify.atlassian.net/browse/PIMCORE-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ